### PR TITLE
.github/workflows/*ha-frontend*: fix check for latest release

### DIFF
--- a/.github/workflows/check-ha-frontend-release.yml
+++ b/.github/workflows/check-ha-frontend-release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Get latest version
       id: latest-version
       run: |
-        git ls-remote --tags --sort="version:refname" https://github.com/home-assistant/frontend.git|grep -E "refs/tags/20[2-9][0-9]{5}\.[0-9]$"|tail -1|awk -F / '{print $3}' > latest-release
+        wget -qO - https://api.github.com/repos/home-assistant/frontend/releases/latest|jq -r '.tag_name' > latest-release
         cat latest-release
         echo "::set-output name=latest-version::$(cat latest-release)"
 

--- a/.github/workflows/make-ha-frontend-sdist.yml
+++ b/.github/workflows/make-ha-frontend-sdist.yml
@@ -16,8 +16,8 @@ jobs:
     - name: get-version
       id: get-version
       run: |
-        git ls-remote --tags --sort='version:refname' https://github.com/home-assistant/frontend.git|grep -E 'refs/tags/20[2-9][0-9]{5}\.[0-9]$'|tail -1|awk -F / '{print $3}'
-        echo "::set-output name=version::$(git ls-remote --tags --sort='version:refname' https://github.com/home-assistant/frontend.git|grep -E 'refs/tags/20[2-9][0-9]{5}\.[0-9]$'|tail -1|awk -F / '{print $3}')"
+        wget -qO - https://api.github.com/repos/home-assistant/frontend/releases/latest|jq -r '.tag_name'
+        echo "::set-output name=version::$(wget -qO - https://api.github.com/repos/home-assistant/frontend/releases/latest|jq -r '.tag_name')"
 
     - name: Checkout frontend repository
       uses: actions/checkout@v3

--- a/.github/workflows/make-ha-frontend-sdist.yml
+++ b/.github/workflows/make-ha-frontend-sdist.yml
@@ -2,6 +2,11 @@ name: 'HA Frontend - make SDIST'
 
 on:
   workflow_dispatch:
+    inputs:
+      frontend_version:
+        description: 'Home Assistant Frontend Version'
+        required: true
+        default: 'latest'
     
 env:
   PYTHON_VERSION: 3.8
@@ -16,8 +21,13 @@ jobs:
     - name: get-version
       id: get-version
       run: |
-        wget -qO - https://api.github.com/repos/home-assistant/frontend/releases/latest|jq -r '.tag_name'
-        echo "::set-output name=version::$(wget -qO - https://api.github.com/repos/home-assistant/frontend/releases/latest|jq -r '.tag_name')"
+        if [ "${{ github.event.inputs.frontend_version }}" == "latest"  ];then
+          wget -qO - https://api.github.com/repos/home-assistant/frontend/releases/latest|jq -r '.tag_name'
+          echo "::set-output name=version::$(wget -qO - https://api.github.com/repos/home-assistant/frontend/releases/latest|jq -r '.tag_name')"
+        else
+          echo "${{ github.event.inputs.frontend_version }}"
+          echo "::set-output name=version::${{ github.event.inputs.frontend_version }}"
+        fi
 
     - name: Checkout frontend repository
       uses: actions/checkout@v3


### PR DESCRIPTION
now we only check for "real releases", not for every tag in ha-frontend repo.

For convenience, I also added the ability to explicitly specify the relaease tag on manual workflow trigger


Signed-off-by: Anton Fischl <github@fischl-online.de>