### PR TITLE
dev-python/gstreamer-player: add missing pygobject dependency

### DIFF
--- a/dev-python/gstreamer-player/gstreamer-player-1.1.2.ebuild
+++ b/dev-python/gstreamer-player/gstreamer-player-1.1.2.ebuild
@@ -20,6 +20,7 @@ RESTRICT="!test? ( test )"
 DOCS=""
 
 RDEPEND=">=media-libs/mutagen-1.36.2[${PYTHON_USEDEP}]
+	>=dev-python/pygobject-3.42.2[${PYTHON_USEDEP}]
 	>=dev-python/lxml-3.6.0[${PYTHON_USEDEP}]"
 BDEPEND="
 	dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
On a fresh install, gstreamer-player fails to load stating:
```
  File "/usr/lib/python3.10/site-packages/gsp/__init__.py", line 11, in <module>
    import gi  # pylint: disable=import-error
ModuleNotFoundError: No module named 'gi'
```

This is caused by a missing dependency to pull in pygobject. Explicitly adding the dependency should solve the issue.