### PR TITLE
Mutagen is exclusively used by TTS integration and version 1.46.0, se…

### DIFF
--- a/app-misc/homeassistant-full/homeassistant-full-2023.1.2.ebuild
+++ b/app-misc/homeassistant-full/homeassistant-full-2023.1.2.ebuild
@@ -127,8 +127,7 @@ RDEPEND="${RDEPEND}
 	~dev-python/pyotp-2.7.0[${PYTHON_USEDEP}]
 	>=dev-python/pyqrcode-1.2.1[${PYTHON_USEDEP}]
 	dev-python/pycparser[${PYTHON_USEDEP}]
-	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]
-	~media-libs/mutagen-1.45.1"
+	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]"
 # Module requirements from useflags
 RDEPEND="${RDEPEND}
 	abode? ( ~dev-python/abodepy-1.2.0[${PYTHON_USEDEP}] )

--- a/app-misc/homeassistant-full/homeassistant-full-9999.ebuild
+++ b/app-misc/homeassistant-full/homeassistant-full-9999.ebuild
@@ -127,8 +127,7 @@ RDEPEND="${RDEPEND}
 	~dev-python/pyotp-2.7.0[${PYTHON_USEDEP}]
 	>=dev-python/pyqrcode-1.2.1[${PYTHON_USEDEP}]
 	dev-python/pycparser[${PYTHON_USEDEP}]
-	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]
-	~media-libs/mutagen-1.45.1"
+	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]"
 # Module requirements from useflags
 RDEPEND="${RDEPEND}
 	abode? ( ~dev-python/abodepy-1.2.0[${PYTHON_USEDEP}] )

--- a/app-misc/homeassistant-min/homeassistant-min-2023.1.2.ebuild
+++ b/app-misc/homeassistant-min/homeassistant-min-2023.1.2.ebuild
@@ -127,8 +127,7 @@ RDEPEND="${RDEPEND}
 	~dev-python/pyotp-2.7.0[${PYTHON_USEDEP}]
 	>=dev-python/pyqrcode-1.2.1[${PYTHON_USEDEP}]
 	dev-python/pycparser[${PYTHON_USEDEP}]
-	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]
-	~media-libs/mutagen-1.45.1"
+	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]"
 # Module requirements from useflags
 RDEPEND="${RDEPEND}
 	accuweather? ( ~dev-python/accuweather-0.4.0[${PYTHON_USEDEP}] )

--- a/app-misc/homeassistant/homeassistant-2023.1.2.ebuild
+++ b/app-misc/homeassistant/homeassistant-2023.1.2.ebuild
@@ -127,8 +127,7 @@ RDEPEND="${RDEPEND}
 	~dev-python/pyotp-2.7.0[${PYTHON_USEDEP}]
 	>=dev-python/pyqrcode-1.2.1[${PYTHON_USEDEP}]
 	dev-python/pycparser[${PYTHON_USEDEP}]
-	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]
-	~media-libs/mutagen-1.45.1"
+	>=dev-python/websocket-client-0.57.0[${PYTHON_USEDEP}]"
 # Module requirements from useflags
 RDEPEND="${RDEPEND}
 	abode? ( ~dev-python/abodepy-1.2.0[${PYTHON_USEDEP}] )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -640,7 +640,6 @@ mt_940==4.26.0
 mullvad-api==1.0.0
 multidict==6.0.4
 munch==2.5.0
-mutagen==1.45.1
 mutagen==1.46.0
 mutesync==0.0.1
 mychevy==2.1.1


### PR DESCRIPTION
Mutagen is exclusively used by TTS integration and version 1.46.0, see source code homeassistant/components/tts/manifest.json