### PR TITLE
Update protobuf-python-4.24.3-r1.ebuild

### DIFF
--- a/dev-python/protobuf-python/protobuf-python-4.24.3-r1.ebuild
+++ b/dev-python/protobuf-python/protobuf-python-4.24.3-r1.ebuild
@@ -45,7 +45,7 @@ DEPEND="
 "
 RDEPEND="
 	${BDEPEND}
-	dev-libs/protobuf:${SLOT}=
+	dev-libs/protobuf:${SLOT}
 "
 
 distutils_enable_tests setup.py


### PR DESCRIPTION
fix ebuild = in slot


I have this error and I use this fix 

 ```
 !!! All ebuilds that could satisfy ">=dev-python/protobuf-python-4.24.3[python_targets_python3_11(-)?]" have been masked.
!!! One of the following masked packages is required to complete your request:
- dev-python/protobuf-python-9999::gentoo (masked by: missing keyword)
- dev-python/protobuf-python-4.24.3-r1::HomeAssistantRepository (masked by: invalid: BDEPEND: Improper context for slot-operator "built" atom syntax: dev-libs/protobuf:0/24.3.0=, invalid: RDEPEND: Improper context for slot-operator "built" atom syntax: dev-libs/protobuf:0/24.3.0=)

```